### PR TITLE
Configurable http timeouts

### DIFF
--- a/lib/synapse_pay_rest/http_client.rb
+++ b/lib/synapse_pay_rest/http_client.rb
@@ -46,7 +46,7 @@ module SynapsePayRest
     end
 
     # Returns headers for HTTP requests.
-    # 
+    #
     # @return [Hash]
     def headers
       user    = "#{config[:oauth_key]}|#{config[:fingerprint]}"
@@ -63,13 +63,13 @@ module SynapsePayRest
     alias_method :get_headers, :headers
 
     # Updates headers.
-    # 
+    #
     # @param oauth_key [String,void]
     # @param fingerprint [String,void]
     # @param client_id [String,void]
     # @param client_secret [String,void]
     # @param ip_address [String,void]
-    # 
+    #
     # @return [void]
     def update_headers(oauth_key: nil, fingerprint: nil, client_id: nil,
                        client_secret: nil, ip_address: nil, **options)
@@ -82,13 +82,13 @@ module SynapsePayRest
     end
 
     # Sends a POST request to the given path with the given payload.
-    # 
+    #
     # @param path [String]
     # @param payload [Hash]
     # @param idempotency_key [String] (optional) avoid accidentally performing the same operation twice
     #
     # @raise [SynapsePayRest::Error] subclass depends on HTTP response
-    # 
+    #
     # @return [Hash] API response
     def post(path, payload, **options)
       headers = get_headers
@@ -102,12 +102,12 @@ module SynapsePayRest
     end
 
     # Sends a PATCH request to the given path with the given payload.
-    # 
+    #
     # @param path [String]
     # @param payload [Hash]
-    # 
+    #
     # @raise [SynapsePayRest::Error] subclass depends on HTTP response
-    # 
+    #
     # @return [Hash] API response
     def patch(path, payload)
       response = with_error_handling { RestClient::Request.execute(:method => :patch, :url => full_url(path), :payload => payload.to_json, :headers => headers, :timeout => timeout) }
@@ -116,11 +116,11 @@ module SynapsePayRest
     end
 
     # Sends a GET request to the given path with the given payload.
-    # 
+    #
     # @param path [String]
-    # 
+    #
     # @raise [SynapsePayRest::Error] subclass depends on HTTP response
-    # 
+    #
     # @return [Hash] API response
     def get(path)
       response = with_error_handling { RestClient.get(full_url(path), headers) }
@@ -129,11 +129,11 @@ module SynapsePayRest
     end
 
     # Sends a DELETE request to the given path with the given payload.
-    # 
+    #
     # @param path [String]
-    # 
+    #
     # @raise [SynapsePayRest::Error] subclass depends on HTTP response
-    # 
+    #
     # @return [Hash] API response
     def delete(path)
       response = with_error_handling { RestClient.delete(full_url(path), headers) }
@@ -160,7 +160,7 @@ module SynapsePayRest
       }
       raise Error.from_response(body)
     rescue RestClient::Exception => e
-      if e.response.headers[:content_type] == 'application/json' 
+      if e.response.headers[:content_type] == 'application/json'
         body = JSON.parse(e.response.body)
       else
         body = {

--- a/lib/synapse_pay_rest/http_client.rb
+++ b/lib/synapse_pay_rest/http_client.rb
@@ -4,6 +4,8 @@ require 'json'
 module SynapsePayRest
   # Wrapper for HTTP requests using RestClient.
   class HTTPClient
+    DEFAULT_TIMEOUT_IN_SECONDS = 300
+
     # @!attribute [rw] base_url
     #   @return [String] the base url of the API (production or sandbox)
     # @!attribute [rw] config
@@ -30,6 +32,8 @@ module SynapsePayRest
 
       RestClient.proxy = options[:proxy_url] if options[:proxy_url]
       @proxy_url = options[:proxy_url]
+
+      @timeout = options[:timeout] || DEFAULT_TIMEOUT_IN_SECONDS
 
       @config = {
         client_id:     client_id,
@@ -92,7 +96,7 @@ module SynapsePayRest
         headers = headers.merge({'X-SP-IDEMPOTENCY-KEY' => options[:idempotency_key]})
       end
 
-      response = with_error_handling { RestClient::Request.execute(:method => :post, :url => full_url(path), :payload => payload.to_json, :headers => headers, :timeout => 300) }
+      response = with_error_handling { RestClient::Request.execute(:method => :post, :url => full_url(path), :payload => payload.to_json, :headers => headers, :timeout => timeout) }
       p 'RESPONSE:', JSON.parse(response) if @logging
       JSON.parse(response)
     end
@@ -106,7 +110,7 @@ module SynapsePayRest
     # 
     # @return [Hash] API response
     def patch(path, payload)
-      response = with_error_handling { RestClient::Request.execute(:method => :patch, :url => full_url(path), :payload => payload.to_json, :headers => headers, :timeout => 300) }
+      response = with_error_handling { RestClient::Request.execute(:method => :patch, :url => full_url(path), :payload => payload.to_json, :headers => headers, :timeout => timeout) }
       p 'RESPONSE:', JSON.parse(response) if @logging
       JSON.parse(response)
     end
@@ -138,6 +142,8 @@ module SynapsePayRest
     end
 
     private
+
+    attr_reader :timeout
 
     def full_url(path)
       "#{base_url}#{path}"

--- a/synapse_pay_rest.gemspec
+++ b/synapse_pay_rest.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rest-client', '~> 2.0'
 
-  s.add_development_dependency 'bundler', '~> 1.10'
+  s.add_development_dependency 'bundler', '~> 2.0'
   s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'minitest', '~> 5.8.2'
   s.add_development_dependency 'minitest-reporters', '~> 1.1.5'


### PR DESCRIPTION
This allows users of the gem to pass their own timeout to the HTTPClient, rather than use a hard-coded 300 second timeout.

This is useful as some users of the gem may want requests to timeout quicker in case they are making syncronous requests to SynapseFi, for example.